### PR TITLE
Adapt to version 3 of dune

### DIFF
--- a/bin/web/bench.ml
+++ b/bin/web/bench.ml
@@ -3,10 +3,6 @@ open Brr
 open Brr_io
 open Fut.Syntax
 
-let alert v =
-  let alert = Jv.get Jv.global "alert" in
-  ignore @@ Jv.apply alert Jv.[| of_string v |]
-
 let find_el_by_id id = Document.find_el_by_id G.document (Jstr.v id) |> Option.get
 
 let run_rom_bytes rom_bytes frames =

--- a/bin/web/index.ml
+++ b/bin/web/index.ml
@@ -21,12 +21,6 @@ let rom_options = [
   {name = "SHEEP IT UP"       ; path = "./sheep-it-up.gb"};
 ]
 
-let alert v =
-  let alert = Jv.get Jv.global "alert" in
-  ignore @@ Jv.apply alert Jv.[| of_string v |]
-
-let console_log s = Console.log Jstr.[of_string s]
-
 let find_el_by_id id = Document.find_el_by_id G.document (Jstr.v id) |> Option.get
 
 let draw_framebuffer ctx image_data fb =

--- a/camlboy.opam
+++ b/camlboy.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/linoscope/CAMLBOY"
 doc: "https://github.com/linoscope/CAMLBOY"
 bug-reports: "https://github.com/linoscope/CAMLBOY/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.6"}
   "brr" {>= "0.0.2"}
   "js_of_ocaml-compiler" {>= "3.11.0"}
   "js_of_ocaml-lwt" {>= "3.11.0"}
@@ -29,11 +29,9 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/linoscope/CAMLBOY.git"

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.9)
+(lang dune 3.6)
 
 (generate_opam_files true)
 
@@ -15,6 +15,7 @@
 
 (package
  (name camlboy)
+ (allow_empty)
  (synopsis "A Gambeboy emulator written in OCaml")
  (description "A Gambeboy emulator written in OCaml")
  (depends

--- a/lib/camlboy.mli
+++ b/lib/camlboy.mli
@@ -1,1 +1,1 @@
-module Make (Cartridge : Cartridge_intf.S) : Camlboy_intf.S
+module Make (_ : Cartridge_intf.S) : Camlboy_intf.S

--- a/lib/dune
+++ b/lib/dune
@@ -3,3 +3,5 @@
  (libraries bigstringaf))
 
 (include_subdirs unqualified)
+
+(env (_  (flags (:standard -w -69))))


### PR DESCRIPTION
This project does not build without changing the line `(lang dune 2.9)` in `dune-project` since otherwise the Js_of_ocaml flags are also passed to the Js_of_ocaml linker, which does not understand `--no-inline`.

And then, there are a few additional warnings to address.